### PR TITLE
refactor(apps): protocol

### DIFF
--- a/src/modules/artifacts/ArtifactSharedIframe.tsx
+++ b/src/modules/artifacts/ArtifactSharedIframe.tsx
@@ -39,19 +39,20 @@ export function ArtifactSharedIframe({ artifact, token }: Props) {
     );
   }, [iframeLoadCount]);
 
-  const [appState, setAppState] = useState<AppState>({
-    code: artifact.source_code ?? 'async def main():\n  pass',
-    theme: theme,
-    fullscreen: true,
-    ancestorOrigin: '',
-    config: {
-      canFixError: false
-    }
-  });
-  useEffect(() => { setAppState(state => ({ ...state, ancestorOrigin: window.location.origin })); }, []);
-  useEffect(() => { setAppState(state => ({ ...state, theme })) }, [theme]);
-  useEffect(() => { if(artifact.source_code) setAppState(state => ({ ...state, code: artifact.source_code as string })) }, [artifact.source_code]);
-  useEffect(() => { postMessage({ type: PostMessageType.UPDATE_STATE, stateChange: appState }) }, [appState, postMessage]);
+  useEffect(() => {
+    postMessage({
+      type: PostMessageType.UPDATE_STATE,
+      stateChange: {
+        code: artifact.source_code ?? undefined,
+        theme: theme,
+        fullscreen: true,
+        ancestorOrigin: window.location.origin,
+        config: {
+          canFixError: false
+        }
+      }
+    })
+  }, [artifact.source_code, postMessage, theme]);
 
   const handleMessage = useCallback(
     async (event: MessageEvent<StliteMessage>) => {

--- a/src/modules/artifacts/ArtifactSharedIframe.tsx
+++ b/src/modules/artifacts/ArtifactSharedIframe.tsx
@@ -136,20 +136,18 @@ export function ArtifactSharedIframe({ artifact, token }: Props) {
   );
 }
 
-interface AppState {
-  fullscreen: boolean,
-  theme: 'light' | 'dark' | 'system',
-  code: string,
-  config: {
-    canFixError: boolean
-  },
-  ancestorOrigin: string,
-}
-
 type PostMessage =
   | {
       type: PostMessageType.UPDATE_STATE;
-      stateChange: Partial<AppState>;
+      stateChange: Partial<{
+        fullscreen: boolean,
+        theme: 'light' | 'dark' | 'system',
+        code: string,
+        config: {
+          canFixError: boolean
+        },
+        ancestorOrigin: string,
+      }>;
     }
   | {
       type: PostMessageType.RESPONSE;


### PR DESCRIPTION
These PRs need to be merged and deployed together:
- https://github.com/i-am-bee/bee-usercontent-site/pull/37
- https://github.com/i-am-bee/bee-ui/pull/171
- https://github.com/i-am-bee/bee-artifacts-site/pull/23

Changes (in all these PRs):
- Simplify messaging and state handling -- synchronize a single state object between apps
- Use the request mechanism for "Fix error"
- Send ready event as soon as the app starts running (perceptively faster app load)
- Track ancestor origin, avoid a barrage of mismatched origin warnings in console
- Properly sync the sandboxed frame if it reloads by itself (useful in dev)
- Unify naming in some cases